### PR TITLE
Fix libxml2 static ldflags

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -63,8 +63,7 @@ target_link_libraries(ebc
   ${ICONV_LIBRARY}
   ${XAR_LIBRARY}
   ${LLVM_LINK_LIBRARIES}
-  ${LIBXML2_LIBRARIES}
-  ${PC_LIBXML_STATIC_LIBRARIES})
+  ${LIBXML2_STATIC_LDFLAGS})
 
 target_include_directories(ebc PRIVATE  ${PROJECT_BINARY_DIR})
 target_include_directories(ebc PUBLIC ${HEADER_DIR})


### PR DESCRIPTION
`PC_LIBXML` is outright the wrong prefix, `LIBXML2_LIBRARIES` is not enough for static linking as it doesn't contain the dependencies:

```
LIBXML2_LIBRARIES:INTERNAL=xml2
```

```
ld: error: undefined symbol: lzma_properties_decode
>>> referenced by xzlib.o:(xz_make) in archive /usr/local/lib/libxml2.a
…
```

What works is

```
LIBXML2_STATIC_LDFLAGS:INTERNAL=-L/usr/local/lib;-lxml2;-lz;-llzma;-lm
```

but it's unfortunate that cmake doesn't create an imported targets for static linking. 